### PR TITLE
Update SchService.ps1

### DIFF
--- a/Powershell/SchService.ps1
+++ b/Powershell/SchService.ps1
@@ -963,7 +963,7 @@ if ($Control) {                 # Send a control message to the service
 
     # Set up the scheduled events URI for a VNET-enabled VM
     $localHostIP = "169.254.169.254"
-    $scheduledEventURI = 'http://{0}/metadata/scheduledevents?api-version=2017-03-01' -f $localHostIP 
+    $scheduledEventURI = 'http://{0}/metadata/scheduledevents?api-version=2017-11-01' -f $localHostIP 
     $eventSource = "AzureScheduledEvents" 
     $eventLogName = "Application"
     $eventLogId = 1234   


### PR DESCRIPTION
From MS docs we can see that the version for scheduled events should be 2017-11-01 (https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events)
On line 966 we see that the version in use for this PS is 2017-03-01

Is it possible to change the line of the version of Scheduled events under this PS to show the same version as the supported one?